### PR TITLE
docs(ai-sdlc): document AutoWonder build environment

### DIFF
--- a/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/SKILL.md
+++ b/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/SKILL.md
@@ -20,6 +20,15 @@ If a manifest exists, ask whether to resume it or create a distinct deployment.
 Never apply merely because configuration files exist. QA and diagnosis must not
 invoke mutation scripts.
 
+## Build And Runtime Environment
+
+| Purpose | Supported environment |
+| --- | --- |
+| Source package | JDK 21 and Maven 3.9.9; Maven downloads the pinned Node.js and npm versions automatically |
+| Frontend only | Node.js 22.22.2 and npm 10.9.7 |
+| Container build | Docker with BuildKit; the Dockerfile pins Maven 3.9.9, JDK 21, and the Java 21 runtime |
+| Deployment | Bash, Git, jq, Terraform, Alibaba Cloud CLI, ossutil, OpenSSL, and curl on the control host; Linux x86_64 with Java 21 on ECS |
+
 ## Initial Questionnaire
 
 For new deployment, read `references/input-catalog.md` and ask **one consolidated questionnaire**

--- a/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/tests/test_skill_bundle.py
+++ b/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/tests/test_skill_bundle.py
@@ -132,6 +132,19 @@ class SkillBundleTest(unittest.TestCase):
         for script in [path for path in REQUIRED if path.startswith("scripts/")]:
             self.assertIn(script, skill)
 
+    def test_skill_documents_portable_build_environment(self):
+        skill = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        for term in [
+            "## Build And Runtime Environment",
+            "JDK 21",
+            "Maven 3.9.9",
+            "Node.js 22.22.2",
+            "npm 10.9.7",
+            "downloads the pinned Node.js and npm versions",
+            "Linux x86_64",
+        ]:
+            self.assertIn(term, skill, f"SKILL.md must document {term!r}")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
  Skill 新增了精简环境说明：

  - JDK 21
  - Maven 3.9.9
  - Node.js 22.22.2
  - npm 10.9.7
  - Maven 自动下载 Node/npm
  - Docker BuildKit
  - Linux x86_64 + Java 21 ECS 运行环境
  - 部署控制机所需基础命令

  部署 Skill 全部 38 项测试通过