### PR TITLE
Feat/autowonder squad templates 20260805

### DIFF
--- a/ai-sdlc/auto-wonder/docs/autowonder-community-templates.sql
+++ b/ai-sdlc/auto-wonder/docs/autowonder-community-templates.sql
@@ -1,0 +1,79 @@
+-- AutoWonder Community system squad templates.
+-- Idempotent by system template name; no fixed database IDs are used.
+
+SET @template_solo = '{"template":{"name":"独立开发者","description":"一人全栈完成需求分析、开发、自测和交付，适合小型需求与缺陷修复。","squadSize":1,"icon":"solo","tags":"推荐,快速"},"squad":{"name":"独立开发者小队","description":"单人负责从需求理解到可验证交付的完整闭环。"},"agents":[{"name":"全栈开发","roleCode":"FS_DEV","roleName":"前后端全栈开发","businessBackground":"面向通用软件项目，在 {{SOURCE_REPOSITORY}} 中完成前后端或客户端研发交付。","responsibilities":"理解工单边界，完成设计、编码、配套测试、自审和分支交付。不得扩展未授权范围、隐藏失败、删除测试或写入凭据。重大接口、数据和安全取舍必须交回真人确认。","sdlc":{"name":"独立开发者 SDLC","description":"需求分析、实现、验证和交付。","steps":[{"order":1,"name":"需求分析","kind":"WORK","required":true,"instruction":"阅读工单与澄清材料，确认需求、验收条件和影响范围。信息不足时先评论澄清；明确后从权威基线创建唯一业务分支。"},{"order":2,"name":"实现与测试","kind":"WORK","required":true,"instruction":"按确认范围实现需求并补充相关测试。保持提交聚焦，不修改无关模块，不降低既有质量门槛。"},{"order":3,"name":"自测与自审","kind":"WORK","required":true,"instruction":"运行受影响模块测试和必要构建，审查正确性、安全、边界与回归风险，记录实际命令和结果。"},{"order":4,"name":"交付","kind":"HANDOFF","required":true,"instruction":"推送分支并通过 {{CODE_PLATFORM}} 创建 MR 或 PR。可用且获授权时通过 {{DEPLOYMENT_PLATFORM}} 部署验证；汇报分支、提交、评审链接、测试和风险后交回真人。"}]}}]}';
+
+UPDATE squad_template
+SET description = JSON_UNQUOTE(JSON_EXTRACT(@template_solo, '$.template.description')),
+    squad_size = JSON_EXTRACT(@template_solo, '$.template.squadSize'),
+    icon = JSON_UNQUOTE(JSON_EXTRACT(@template_solo, '$.template.icon')),
+    tags = JSON_UNQUOTE(JSON_EXTRACT(@template_solo, '$.template.tags')),
+    content_json = JSON_REMOVE(@template_solo, '$.template'), status = 'ACTIVE', is_deleted = 0
+WHERE tenant_id IS NULL AND name = JSON_UNQUOTE(JSON_EXTRACT(@template_solo, '$.template.name'));
+INSERT INTO squad_template (tenant_id, name, description, squad_size, icon, tags, content_json, status, is_deleted)
+SELECT NULL, JSON_UNQUOTE(JSON_EXTRACT(@template_solo, '$.template.name')),
+       JSON_UNQUOTE(JSON_EXTRACT(@template_solo, '$.template.description')),
+       JSON_EXTRACT(@template_solo, '$.template.squadSize'),
+       JSON_UNQUOTE(JSON_EXTRACT(@template_solo, '$.template.icon')),
+       JSON_UNQUOTE(JSON_EXTRACT(@template_solo, '$.template.tags')),
+       JSON_REMOVE(@template_solo, '$.template'), 'ACTIVE', 0
+WHERE NOT EXISTS (SELECT 1 FROM squad_template WHERE tenant_id IS NULL AND name = JSON_UNQUOTE(JSON_EXTRACT(@template_solo, '$.template.name')));
+
+SET @template_pair = '{"template":{"name":"开发+评审双人组","description":"开发完成后由独立代码评审角色核对规格、实现和测试，适合重视代码质量的迭代。","squadSize":2,"icon":"pair","tags":"质量,协作"},"squad":{"name":"开发与评审小队","description":"开发交付后进入独立评审，评审不通过时按稳定问题清单返工。"},"agents":[{"name":"全栈开发","roleCode":"FS_DEV","roleName":"前后端全栈开发","businessBackground":"在 {{SOURCE_REPOSITORY}} 中承担通用软件需求和缺陷交付。","responsibilities":"负责需求分析、实现、配套测试和分支交付；返工时逐项处理评审问题，不另建无关分支或扩大范围。","sdlc":{"name":"开发 SDLC","description":"开发与评审返工闭环。","steps":[{"order":1,"name":"分析与分支准备","kind":"WORK","required":true,"instruction":"阅读工单和前序反馈。首次开发从权威基线建分支；返工继续原分支并列出全部待修问题。"},{"order":2,"name":"编码与测试","kind":"WORK","required":true,"instruction":"实现确认范围，补充相关测试并逐项核销返工问题。"},{"order":3,"name":"验证与交付","kind":"WORK","required":true,"instruction":"完成必要构建和测试，推送分支，通过 {{CODE_PLATFORM}} 创建或更新 MR 或 PR，汇报实际提交范围。"},{"order":4,"name":"交接评审","kind":"HANDOFF","required":true,"instruction":"把工单、分支、提交范围、评审链接、测试证据和风险交接给 roleCode=CR。"}]}},{"name":"代码评审","roleCode":"CR","roleName":"代码评审专家","businessBackground":"独立核对软件交付与需求规格，关注正确性、安全性、可维护性和测试充分性。","responsibilities":"只评审工单关联的累计变更，不直接修改代码。结论必须为 PASS 或 REJECT；REJECT 需给出稳定编号、代码证据和可执行方向。","sdlc":{"name":"代码评审 SDLC","description":"规格评审、代码评审和返工反馈。","steps":[{"order":1,"name":"校验评审范围","kind":"WORK","required":true,"instruction":"读取工单、前序交付和 {{CODE_PLATFORM}} 上的 MR 或 PR，校验权威 base 与 head，确定首次评审或返工复审。"},{"order":2,"name":"执行评审","kind":"WORK","required":true,"instruction":"核对需求完整性、实现正确性、安全、边界和测试。首次尽量一次列齐实质问题；复审优先核销原问题。"},{"order":3,"name":"结论与交接","kind":"HANDOFF","required":true,"instruction":"PASS 时汇报结论并交回真人；REJECT 时保存稳定问题清单并交接给 roleCode=FS_DEV 返工。"}]}}]}';
+
+UPDATE squad_template
+SET description = JSON_UNQUOTE(JSON_EXTRACT(@template_pair, '$.template.description')),
+    squad_size = JSON_EXTRACT(@template_pair, '$.template.squadSize'),
+    icon = JSON_UNQUOTE(JSON_EXTRACT(@template_pair, '$.template.icon')),
+    tags = JSON_UNQUOTE(JSON_EXTRACT(@template_pair, '$.template.tags')),
+    content_json = JSON_REMOVE(@template_pair, '$.template'), status = 'ACTIVE', is_deleted = 0
+WHERE tenant_id IS NULL AND name = JSON_UNQUOTE(JSON_EXTRACT(@template_pair, '$.template.name'));
+INSERT INTO squad_template (tenant_id, name, description, squad_size, icon, tags, content_json, status, is_deleted)
+SELECT NULL, JSON_UNQUOTE(JSON_EXTRACT(@template_pair, '$.template.name')),
+       JSON_UNQUOTE(JSON_EXTRACT(@template_pair, '$.template.description')),
+       JSON_EXTRACT(@template_pair, '$.template.squadSize'),
+       JSON_UNQUOTE(JSON_EXTRACT(@template_pair, '$.template.icon')),
+       JSON_UNQUOTE(JSON_EXTRACT(@template_pair, '$.template.tags')),
+       JSON_REMOVE(@template_pair, '$.template'), 'ACTIVE', 0
+WHERE NOT EXISTS (SELECT 1 FROM squad_template WHERE tenant_id IS NULL AND name = JSON_UNQUOTE(JSON_EXTRACT(@template_pair, '$.template.name')));
+
+SET @template_delivery = '{"template":{"name":"标准研发交付小队","description":"开发、独立评审和测试验收组成的标准研发质量闭环。","squadSize":3,"icon":"team","tags":"完整,正式"},"squad":{"name":"标准研发交付小队","description":"开发完成后依次进行代码评审和独立测试验收。"},"agents":[{"name":"全栈开发","roleCode":"FS_DEV","roleName":"前后端全栈开发","businessBackground":"在 {{SOURCE_REPOSITORY}} 中负责通用软件需求和缺陷实现。","responsibilities":"按工单范围完成设计、编码、测试和分支交付；评审或测试打回时在原交付分支逐项返工。","sdlc":{"name":"标准开发 SDLC","description":"开发、验证和交接评审。","steps":[{"order":1,"name":"需求与反馈分析","kind":"WORK","required":true,"instruction":"确认需求、验收条件、权威基线和全部前序反馈，形成聚焦的实施方案。"},{"order":2,"name":"实现与配套测试","kind":"WORK","required":true,"instruction":"实现确认范围并补充相关自动化测试，不跳过失败或修改无关代码。"},{"order":3,"name":"构建与分支交付","kind":"WORK","required":true,"instruction":"运行必要构建和测试，推送业务分支并通过 {{CODE_PLATFORM}} 创建或更新 MR 或 PR。"},{"order":4,"name":"交接代码评审","kind":"HANDOFF","required":true,"instruction":"把权威提交范围、评审链接、测试证据和风险交接给 roleCode=CR。"}]}},{"name":"代码评审","roleCode":"CR","roleName":"代码评审专家","businessBackground":"独立评估交付是否满足规格、工程质量和安全要求。","responsibilities":"对累计变更进行事实驱动的规格与代码评审。PASS 交给测试；REJECT 以稳定问题清单打回开发。","sdlc":{"name":"标准评审 SDLC","description":"累计变更评审和返工复审。","steps":[{"order":1,"name":"确认上下文","kind":"WORK","required":true,"instruction":"校验工单、直接前序交付、{{CODE_PLATFORM}} 评审链接及 base 到 head 的累计范围。"},{"order":2,"name":"规格与代码评审","kind":"WORK","required":true,"instruction":"检查需求覆盖、逻辑、安全、数据一致性、失败边界和配套测试，明确 PASS 或 REJECT。"},{"order":3,"name":"评审交接","kind":"HANDOFF","required":true,"instruction":"PASS 交接给 roleCode=QA；REJECT 记录具体证据与修改方向后交接给 roleCode=FS_DEV。"}]}},{"name":"测试工程师","roleCode":"QA","roleName":"测试工程师","businessBackground":"独立验证软件交付的功能、回归风险和用户可见行为。","responsibilities":"围绕累计交付范围制定并执行测试，形成可复现报告。测试失败打回开发；通过后按授权进行部署验证并交回真人。","sdlc":{"name":"标准测试验收 SDLC","description":"测试计划、验证、条件部署和验收交接。","steps":[{"order":1,"name":"制定测试计划","kind":"WORK","required":true,"instruction":"读取工单、开发和评审证据，确认验收版本、测试范围及返工重点。"},{"order":2,"name":"执行测试验收","kind":"WORK","required":true,"instruction":"运行与改动匹配的后端、前端或客户端测试；涉及界面时执行真实浏览器验收并保存必要证据。"},{"order":3,"name":"条件部署与交接","kind":"HANDOFF","required":true,"instruction":"测试通过且获授权时通过 {{DEPLOYMENT_PLATFORM}} 执行部署验证。失败则列出复现证据交给 roleCode=FS_DEV；通过则汇报测试和部署状态并交回真人。"}]}}]}';
+
+UPDATE squad_template
+SET description = JSON_UNQUOTE(JSON_EXTRACT(@template_delivery, '$.template.description')),
+    squad_size = JSON_EXTRACT(@template_delivery, '$.template.squadSize'),
+    icon = JSON_UNQUOTE(JSON_EXTRACT(@template_delivery, '$.template.icon')),
+    tags = JSON_UNQUOTE(JSON_EXTRACT(@template_delivery, '$.template.tags')),
+    content_json = JSON_REMOVE(@template_delivery, '$.template'), status = 'ACTIVE', is_deleted = 0
+WHERE tenant_id IS NULL AND name = JSON_UNQUOTE(JSON_EXTRACT(@template_delivery, '$.template.name'));
+INSERT INTO squad_template (tenant_id, name, description, squad_size, icon, tags, content_json, status, is_deleted)
+SELECT NULL, JSON_UNQUOTE(JSON_EXTRACT(@template_delivery, '$.template.name')),
+       JSON_UNQUOTE(JSON_EXTRACT(@template_delivery, '$.template.description')),
+       JSON_EXTRACT(@template_delivery, '$.template.squadSize'),
+       JSON_UNQUOTE(JSON_EXTRACT(@template_delivery, '$.template.icon')),
+       JSON_UNQUOTE(JSON_EXTRACT(@template_delivery, '$.template.tags')),
+       JSON_REMOVE(@template_delivery, '$.template'), 'ACTIVE', 0
+WHERE NOT EXISTS (SELECT 1 FROM squad_template WHERE tenant_id IS NULL AND name = JSON_UNQUOTE(JSON_EXTRACT(@template_delivery, '$.template.name')));
+
+SET @template_full_cycle = '{"template":{"name":"全链路研发协作小队","description":"覆盖需求澄清、项目协调、研发、评审、测试、冲突处理和数据库变更的完整智能研发协作模板。","squadSize":7,"icon":"team","tags":"全链路,治理,推荐"},"squad":{"name":"全链路研发协作小队","description":"开发、评审和测试构成主交付链，其余专家角色按风险与场景调用。"},"agents":[{"name":"需求澄清员","roleCode":"REQ_CLARIFIER","roleName":"需求澄清员","businessBackground":"在研发启动前帮助需求方把目标、边界、约束和验收标准转化为可执行输入。","responsibilities":"通过逐步提问形成需求规格和实施计划。用户明确确认前不上传正式文档；确认后只更新本次需求文档并交回真人。","sdlc":{"name":"需求澄清 SDLC","description":"澄清、方案确认和需求文档交付。","steps":[{"order":1,"name":"识别信息缺口","kind":"WORK","required":true,"instruction":"阅读原始需求，逐项确认目标用户、业务价值、范围边界、约束、风险和验收标准。一次只追问一个关键问题。"},{"order":2,"name":"形成规格与计划","kind":"WORK","required":true,"instruction":"比较可行方案并给出推荐，获得用户确认后形成 requirement-spec.md 和 implementation-plan.md；未确认时继续澄清。"},{"order":3,"name":"确认后交付","kind":"HANDOFF","required":true,"instruction":"仅在用户明确确认后上传两份需求文档。更新时只替换同名旧文档，不删除其他资料；完成后交回真人。"}]}},{"name":"项目管理员","roleCode":"PROJECT_MANAGER","roleName":"项目管理员","businessBackground":"作为研发协作接口人，持续维护需求、工单、负责人、风险、依赖和交付状态。","responsibilities":"理解并澄清请求，通过工单协调合适角色，汇报状态和阻塞。自身不写代码、不改仓库、不创建交付分支；高风险动作必须获得真人确认。","sdlc":{"name":"项目管理 SDLC","description":"请求归纳、工作协调、状态跟踪和真人交接。","steps":[{"order":1,"name":"理解与澄清请求","kind":"WORK","required":true,"instruction":"归纳请求、上下文、优先级、依赖和风险。信息不足时先追问，不臆造项目事实。"},{"order":2,"name":"协调与跟踪","kind":"WORK","required":true,"instruction":"根据明确指令创建、更新、指派或推动工单，选择具备相应职责的数字人；不代替研发角色直接操作 {{SOURCE_REPOSITORY}}。"},{"order":3,"name":"状态汇报与交接","kind":"HANDOFF","required":true,"instruction":"汇报负责人、当前状态、阻塞、风险和下一步。破坏性操作、权限变更和生产变更必须交回真人确认。"}]}},{"name":"全栈开发","roleCode":"FS_DEV","roleName":"前后端全栈开发","businessBackground":"在 {{SOURCE_REPOSITORY}} 中承担前端、后端或客户端的软件研发交付。","responsibilities":"按已确认需求完成实现、配套测试、自测和分支交付；返工时继续权威交付分支逐项处理反馈。","sdlc":{"name":"全链路开发 SDLC","description":"需求分析、实现、自测和评审交接。","steps":[{"order":1,"name":"分析与分支准备","kind":"WORK","required":true,"instruction":"确认需求、验收条件、权威基线和全部直接反馈。首次创建业务分支；返工继续原分支。"},{"order":2,"name":"编码与配套测试","kind":"WORK","required":true,"instruction":"实现确认范围，补充受影响逻辑的测试，检查失败、幂等、并发和安全边界。"},{"order":3,"name":"自测与交付","kind":"WORK","required":true,"instruction":"运行必要构建和测试，提交并推送分支，通过 {{CODE_PLATFORM}} 创建或更新 MR 或 PR，记录 base、head 和证据。"},{"order":4,"name":"交接评审","kind":"HANDOFF","required":true,"instruction":"将累计提交范围、评审链接、测试结果和风险交接给 roleCode=CR。"}]}},{"name":"代码评审专家","roleCode":"CR","roleName":"代码评审专家","businessBackground":"独立评审软件交付的规格一致性、正确性、安全性和测试充分性。","responsibilities":"只评审权威累计变更，不直接改代码。实质问题必须有稳定编号和证据；PASS 交给测试，REJECT 打回开发。","sdlc":{"name":"全链路评审 SDLC","description":"评审范围校验、完整评审和条件交接。","steps":[{"order":1,"name":"校验上下文与冲突","kind":"WORK","required":true,"instruction":"校验工单、base 到 head、{{CODE_PLATFORM}} 评审链接和反馈状态。只读检测与主干的冲突；存在冲突时报告文件，不擅自解决。"},{"order":2,"name":"规格与代码评审","kind":"WORK","required":true,"instruction":"一次性检查需求覆盖、逻辑、安全、数据一致性、边界和测试，明确 PASS 或 REJECT。"},{"order":3,"name":"评审交接","kind":"HANDOFF","required":true,"instruction":"PASS 交接给 roleCode=QA；REJECT 以稳定问题清单和可执行方向交接给 roleCode=FS_DEV。数据库高风险变更交回真人决定是否调用 DBA。"}]}},{"name":"测试工程师","roleCode":"QA","roleName":"测试工程师","businessBackground":"独立验证累计交付的功能正确性、回归风险和用户可见行为。","responsibilities":"制定并执行与变更匹配的测试和必要界面验收。FAIL 打回开发；PASS 后按授权进行部署验证，无论部署结果都交回真人。","sdlc":{"name":"全链路测试 SDLC","description":"版本校验、测试验收、条件部署和交接。","steps":[{"order":1,"name":"上下文与计划","kind":"WORK","required":true,"instruction":"校验权威 head 和前序评审结论，确定首次测试或返工复测范围并评论测试计划。"},{"order":2,"name":"测试验证","kind":"WORK","required":true,"instruction":"执行受影响模块测试；界面改动使用浏览器验收。记录通过、失败、不适用项及可复现证据。"},{"order":3,"name":"条件部署与交接","kind":"HANDOFF","required":true,"instruction":"PASS 且获授权时通过 {{DEPLOYMENT_PLATFORM}} 验证部署。FAIL 交接给 roleCode=FS_DEV；PASS 汇报测试和部署状态并交回真人。"}]}},{"name":"代码冲突解决工程师","roleCode":"CONFLICT_RESOLVER","roleName":"代码冲突解决工程师","businessBackground":"专门分析指定交付分支与主干之间的 merge、rebase 或 cherry-pick 冲突。","responsibilities":"复现冲突并按业务风险分级。仅可自主解决无业务语义变化的低危冲突；高危或不确定冲突必须交回真人决策。","sdlc":{"name":"冲突解决 SDLC","description":"冲突复现、风险分级、低危处理和真人交接。","steps":[{"order":1,"name":"复现与事实采集","kind":"WORK","required":true,"instruction":"确认仓库、目标分支、主干、base 和 head，在 {{SOURCE_REPOSITORY}} 本地工作区复现冲突并记录文件清单；缺少上下文时停止。"},{"order":2,"name":"分级与处理","kind":"WORK","required":true,"instruction":"业务逻辑、接口、数据、安全、并发和发布冲突均为高危，交回真人。仅解决可证明无语义变化的低危冲突，不实现额外需求。"},{"order":3,"name":"验证与真人交接","kind":"HANDOFF","required":true,"instruction":"低危处理后运行最小必要验证并推送原分支；高危不提交试探修改。汇报冲突、分级、处理和证据后只交回真人。"}]}},{"name":"数据库工程师","roleCode":"DBA","roleName":"数据库工程师","businessBackground":"负责检查交付中的数据库变更，并在获授权的目标环境 {{DATABASE_HOST}} / {{DATABASE_NAME}} 上安全执行。连接用户由 {{DATABASE_USER_ENV}} 提供。","responsibilities":"只处理工单或交付 diff 明确包含的 schema、DDL 或 DML。破坏性变更必须先获真人确认并备份；不得输出凭据、扩展变更范围或连接未授权数据库。","sdlc":{"name":"数据库变更 SDLC","description":"变更识别、风险确认、执行验证和真人交接。","steps":[{"order":1,"name":"识别数据库变更","kind":"WORK","required":true,"instruction":"扫描权威交付 diff，列出迁移脚本及 DDL 或 DML，区分常规与破坏性变更。没有数据库变更时明确说明并结束。"},{"order":2,"name":"授权后执行与验证","kind":"WORK","required":true,"instruction":"仅连接 {{DATABASE_HOST}} / {{DATABASE_NAME}}，用户和凭据从 {{DATABASE_USER_ENV}} 读取。破坏性变更先获真人确认并备份，再逐条执行和校验。"},{"order":3,"name":"真人交接","kind":"HANDOFF","required":true,"instruction":"汇报实际语句、影响对象、备份、回滚和验证证据；无变更也明确说明。完成后只交回真人，不自动交接其他数字人。"}]}}]}';
+
+UPDATE squad_template
+SET description = JSON_UNQUOTE(JSON_EXTRACT(@template_full_cycle, '$.template.description')),
+    squad_size = JSON_EXTRACT(@template_full_cycle, '$.template.squadSize'),
+    icon = JSON_UNQUOTE(JSON_EXTRACT(@template_full_cycle, '$.template.icon')),
+    tags = JSON_UNQUOTE(JSON_EXTRACT(@template_full_cycle, '$.template.tags')),
+    content_json = JSON_REMOVE(@template_full_cycle, '$.template'), status = 'ACTIVE', is_deleted = 0
+WHERE tenant_id IS NULL AND name = JSON_UNQUOTE(JSON_EXTRACT(@template_full_cycle, '$.template.name'));
+INSERT INTO squad_template (tenant_id, name, description, squad_size, icon, tags, content_json, status, is_deleted)
+SELECT NULL, JSON_UNQUOTE(JSON_EXTRACT(@template_full_cycle, '$.template.name')),
+       JSON_UNQUOTE(JSON_EXTRACT(@template_full_cycle, '$.template.description')),
+       JSON_EXTRACT(@template_full_cycle, '$.template.squadSize'),
+       JSON_UNQUOTE(JSON_EXTRACT(@template_full_cycle, '$.template.icon')),
+       JSON_UNQUOTE(JSON_EXTRACT(@template_full_cycle, '$.template.tags')),
+       JSON_REMOVE(@template_full_cycle, '$.template'), 'ACTIVE', 0
+WHERE NOT EXISTS (SELECT 1 FROM squad_template WHERE tenant_id IS NULL AND name = JSON_UNQUOTE(JSON_EXTRACT(@template_full_cycle, '$.template.name')));
+
+SET @template_solo = NULL;
+SET @template_pair = NULL;
+SET @template_delivery = NULL;
+SET @template_full_cycle = NULL;

--- a/ai-sdlc/auto-wonder/docs/community/docs-policy.md
+++ b/ai-sdlc/auto-wonder/docs/community/docs-policy.md
@@ -9,6 +9,7 @@ history, not in the published community tree.
 ## Retained Documents
 
 - `docs/autowonder-schema.sql`: complete schema for a fresh installation.
+- `docs/autowonder-community-templates.sql`: idempotent system squad-template seed.
 - `docs/THIRD-PARTY-NOTICES.md`: required third-party notices.
 - `docs/openapi-reference.md`: public server API reference.
 - `docs/scheduler-executor-protocol.md`: server/client runtime protocol.
@@ -21,6 +22,7 @@ history, not in the published community tree.
 - `docs/community/upstream-sync-guide.md`: master-to-community sync rules.
 - `docs/community/upstream-sync-log.md`: verified upstream baselines and history.
 - `docs/community/docs-policy.md`: this retention policy.
+- `docs/community/squad-template-seed.md`: template data and deployment contract.
 
 The deployment Skill under `skills/deploying-autowonder-on-alibaba-cloud/` owns
 the detailed Alibaba Cloud deployment, operations, troubleshooting, acceptance,

--- a/ai-sdlc/auto-wonder/docs/community/squad-template-seed.md
+++ b/ai-sdlc/auto-wonder/docs/community/squad-template-seed.md
@@ -1,0 +1,58 @@
+# Community Squad Template Seed
+
+## Scope
+
+Community installations seed four system `squad_template` rows from
+`docs/autowonder-community-templates.sql`:
+
+1. `独立开发者` with one developer.
+2. `开发+评审双人组` with developer and code reviewer.
+3. `标准研发交付小队` with developer, reviewer, and tester.
+4. `全链路研发协作小队` with requirement clarification, project management,
+   development, review, testing, conflict resolution, and DBA roles.
+
+The first three templates are community-safe exports of the verified development
+templates. The seven-role template is based on the verified AutoWonder
+self-iteration team but contains no project, organization, internal domain,
+database endpoint, credential, or source-system identity.
+
+## Data Contract
+
+- All seeded templates have `tenant_id = NULL`, `status = ACTIVE`, valid JSON,
+  and stable names. The seed updates a matching system template by name or
+  inserts it when absent; it never depends on a fixed database ID.
+- Every agent has a unique generic `roleCode`, community-neutral SOUL and AGENT
+  content, and a non-empty SDLC with at least one step.
+- Development, review, and testing form the normal delivery chain. Requirement
+  clarification, project management, conflict resolution, and DBA are invoked
+  only when needed and return control to a human where their risk boundary
+  requires it.
+- External integrations use only `{{SOURCE_REPOSITORY}}`, `{{CODE_PLATFORM}}`,
+  `{{DEPLOYMENT_PLATFORM}}`, `{{DATABASE_HOST}}`, `{{DATABASE_NAME}}`, and
+  `{{DATABASE_USER_ENV}}` placeholders.
+- Template application retains the existing behavior of granting generated
+  agents write access to the organization's repositories.
+
+## Deployment Contract
+
+The deployment Skill packages and verifies the JAR, schema SQL, and template seed
+SQL. Cloud Assistant transfers all three artifacts to the same versioned ECS
+release directory.
+
+During the existing database subphase, deployment imports the schema first and
+then the template seed. `.database.imported` remains the schema checkpoint;
+`.database.templatesImported` is the template checkpoint. A missing template
+checkpoint on an older manifest runs only the idempotent template seed.
+
+The database phase completes only after the schema postcheck and all four named
+system templates are present, active, and valid JSON. Missing artifacts, checksum
+failure, SQL failure, invalid content, or leaked environment-specific data stops
+the phase without marking it initialized.
+
+## Verification
+
+Automated contracts parse all four payloads, assert agent counts of 1, 2, 3, and
+7, validate unique role codes and non-empty SDLC steps, reject internal or secret
+values, and verify build, transfer, import order, resume behavior, and database
+postconditions. Full backend, frontend, and deployment Skill gates run before
+Community and GitHub branches are pushed.

--- a/ai-sdlc/auto-wonder/docs/community/upstream-sync-log.md
+++ b/ai-sdlc/auto-wonder/docs/community/upstream-sync-log.md
@@ -8,11 +8,40 @@ long-lived `community` branch. Follow the constraints and procedure in the
 
 ## Current Baseline
 
-- Synchronized `origin/master`: `454017b42b961b730fb65964ebb24ff88f36543e`
-- Community merge commit: `fed2ea650c8d27dc938042a6928fcb4306d90222`
-- Synchronized at: 2026-08-04 (Asia/Shanghai)
+- Synchronized `origin/master`: `a4e9ec9e2e8a1adebf1154ea89ef6af88b84278f`
+- Community merge commit: `fa2dbe23c69d4649c9d6345afd5325ec4b9cd190`
+- Synchronized at: 2026-08-05 (Asia/Shanghai)
 
 ## History
+
+### 2026-08-05: `454017b4` to `a4e9ec9e`
+
+| Field | Commit |
+| --- | --- |
+| Previous synchronized baseline | `454017b42b961b730fb65964ebb24ff88f36543e` |
+| Community before merge | `0a79deb016c458561d5ee55f56eed904293d823d` |
+| Merged `origin/master` | `a4e9ec9e2e8a1adebf1154ea89ef6af88b84278f` |
+| Resulting merge commit | `fa2dbe23c69d4649c9d6345afd5325ec4b9cd190` |
+
+Scope: five master-side commits. The merge stops the clarification spinner as
+soon as an agent reply is persisted and adds multiline input behavior to both AI
+conversation panels: Enter sends, Shift+Enter inserts a newline, and IME
+composition does not submit prematurely.
+
+The four upstream frontend files had no community-side change after the previous
+baseline, so master was accepted unchanged. There was no textual conflict,
+documentation-policy input, internal dependency change, executor UI change, or
+product decision.
+
+Verification completed after the merge:
+
+- Backend: 1,713 tests passed; production JAR built.
+- Frontend: 82 test files and 502 tests passed; lint completed with zero errors
+  and two existing hook warnings; production build transformed 4,759 modules.
+- Deployment Skill: 44 contract tests passed.
+- Maven dependency tree and active runtime inputs contained no prohibited
+  internal dependency or domain; excluded documents remained absent and the
+  community executor UI remained Qoder CLI-only.
 
 ### 2026-08-04: `9f984a89` to `454017b4`
 

--- a/ai-sdlc/auto-wonder/frontend/src/features/workitem/clarification/WorkitemClarificationPanel.test.tsx
+++ b/ai-sdlc/auto-wonder/frontend/src/features/workitem/clarification/WorkitemClarificationPanel.test.tsx
@@ -276,4 +276,90 @@ describe('WorkitemClarificationPanel', () => {
     expect(screen.getByText('最终方案')).toBeInTheDocument();
     expect(view.container.querySelector('.ant-spin')).toBeNull();
   });
+
+  it('does not keep spinning after the AI reply is already persisted', async () => {
+    writeClarificationPrefill('100', { squadId: 9, agentId: 42 });
+    mockSquads();
+    const processingConversation = {
+      id: 1, agentId: 42, agentName: 'Agent-X', channelConversationId: 'ch-1',
+      status: 'ACTIVE', executorOnline: true, streamingSupported: true,
+      cliSessionRef: null, processingStatus: 'PROCESSING', processingTurnId: 3,
+      lastTurnAt: '2026-01-01T00:00:03', gmtCreate: '2026-01-01T00:00:00',
+      turns: [
+        { id: 3, direction: 'INBOUND', content: '请给方案', status: 'COMPLETED', error: null, gmtCreate: '2026-01-01T00:00:02' },
+        { id: 4, direction: 'OUTBOUND', content: '请选择 A、B 或 C', status: 'COMPLETED', error: null, gmtCreate: '2026-01-01T00:00:03' },
+      ],
+    };
+    server.use(
+      http.get('/api/workitems/:workitemId/clarification-conversations', () =>
+        HttpResponse.json({ success: true, code: '0', message: '', traceId: null, data: [processingConversation] }),
+      ),
+      http.get('/api/workitems/:workitemId/clarification-conversations/:conversationId', () =>
+        HttpResponse.json({ success: true, code: '0', message: '', traceId: null, data: processingConversation }),
+      ),
+    );
+
+    const view = renderPanel([]);
+
+    expect(await screen.findByText('请选择 A、B 或 C')).toBeInTheDocument();
+    expect(view.container.querySelector('.ant-spin')).toBeNull();
+  });
+
+  it('sends message on Enter key press', async () => {
+    writeClarificationPrefill('100', { squadId: 9, agentId: 42 });
+    mockSquads();
+    mockConversationWithTurns(42);
+    let submitCalled = false;
+    server.use(
+      http.post('/api/workitems/:workitemId/clarification-conversations/:conversationId/turns', () => {
+        submitCalled = true;
+        return HttpResponse.json({ success: true, code: '0', message: '', traceId: null, data: null });
+      }),
+    );
+    renderPanel([]);
+    const textarea = await screen.findByPlaceholderText('输入消息...');
+    fireEvent.change(textarea, { target: { value: '你好' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' });
+    await waitFor(() => expect(submitCalled).toBe(true));
+  });
+
+  it('does not send on Shift+Enter and preserves input content', async () => {
+    writeClarificationPrefill('100', { squadId: 9, agentId: 42 });
+    mockSquads();
+    mockConversationWithTurns(42);
+    let submitCalled = false;
+    server.use(
+      http.post('/api/workitems/:workitemId/clarification-conversations/:conversationId/turns', () => {
+        submitCalled = true;
+        return HttpResponse.json({ success: true, code: '0', message: '', traceId: null, data: null });
+      }),
+    );
+    renderPanel([]);
+    const textarea = await screen.findByPlaceholderText('输入消息...');
+    fireEvent.change(textarea, { target: { value: '第一行' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', shiftKey: true });
+    await new Promise((r) => setTimeout(r, 100));
+    expect(submitCalled).toBe(false);
+    expect(textarea).toHaveValue('第一行');
+  });
+
+  it('does not send when Enter is pressed during IME composition', async () => {
+    writeClarificationPrefill('100', { squadId: 9, agentId: 42 });
+    mockSquads();
+    mockConversationWithTurns(42);
+    let submitCalled = false;
+    server.use(
+      http.post('/api/workitems/:workitemId/clarification-conversations/:conversationId/turns', () => {
+        submitCalled = true;
+        return HttpResponse.json({ success: true, code: '0', message: '', traceId: null, data: null });
+      }),
+    );
+    renderPanel([]);
+    const textarea = await screen.findByPlaceholderText('输入消息...');
+    fireEvent.change(textarea, { target: { value: '候选' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', isComposing: true });
+    await new Promise((r) => setTimeout(r, 100));
+    expect(submitCalled).toBe(false);
+    expect(textarea).toHaveValue('候选');
+  });
 });

--- a/ai-sdlc/auto-wonder/frontend/src/features/workitem/clarification/WorkitemClarificationPanel.tsx
+++ b/ai-sdlc/auto-wonder/frontend/src/features/workitem/clarification/WorkitemClarificationPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Button, Input, Space, Typography, Empty } from 'antd';
+import { Button, Input, Typography, Empty } from 'antd';
 import { SendOutlined, PlusOutlined, UserOutlined, RobotOutlined } from '@ant-design/icons';
 import { AgentSelector } from './AgentSelector';
 import { SquadAgentSelector } from './SquadAgentSelector';
@@ -45,6 +45,7 @@ export function WorkitemClarificationPanel({
 
   const [conversationId, setConversationId] = useState<number | null>(null);
   const [inputValue, setInputValue] = useState('');
+  const composingRef = useRef(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const agentOptions = useMemo(
@@ -99,7 +100,11 @@ export function WorkitemClarificationPanel({
   const awaitingAgentReply = !!streamedText
     && !hasPersistedStreamedReply
     && (streamedTurnCompleted || (!isProcessing && turns.length === turnCountAtSubmitRef.current));
-  const showProcessingEvents = isProcessing && !streamedTurnCompleted;
+  const latestTurn = turns[turns.length - 1];
+  const latestTurnIsAgentReply = !!latestTurn
+    && latestTurn.direction !== 'IN'
+    && latestTurn.direction !== 'INBOUND';
+  const showProcessingEvents = isProcessing && !streamedTurnCompleted && !latestTurnIsAgentReply;
 
   const handleSelectAgent = useCallback(
     (agentId: number) => {
@@ -261,13 +266,24 @@ export function WorkitemClarificationPanel({
 
       {conversationId ? (
         <div style={{ padding: '8px 12px', borderTop: '1px solid #f0f0f0' }}>
-          <Space.Compact style={{ width: '100%' }}>
-            <Input
+          <div style={{ display: 'flex', gap: 8, alignItems: 'flex-end' }}>
+            <Input.TextArea
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
-              onPressEnter={handleSend}
+              onKeyDown={(e) => {
+                if (e.nativeEvent.isComposing || composingRef.current) return;
+                if (e.shiftKey) return;
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleSend();
+                }
+              }}
+              onCompositionStart={() => { composingRef.current = true; }}
+              onCompositionEnd={() => { composingRef.current = false; }}
               placeholder="输入消息..."
+              autoSize={{ minRows: 1, maxRows: 4 }}
               disabled={submitMutation.isPending}
+              style={{ flex: 1 }}
             />
             <Button
               type="primary"
@@ -276,7 +292,7 @@ export function WorkitemClarificationPanel({
               loading={submitMutation.isPending}
               disabled={!inputValue.trim()}
             />
-          </Space.Compact>
+          </div>
         </div>
       ) : null}
     </div>

--- a/ai-sdlc/auto-wonder/frontend/src/shared/ui/AiSessionPanel.test.tsx
+++ b/ai-sdlc/auto-wonder/frontend/src/shared/ui/AiSessionPanel.test.tsx
@@ -1,6 +1,6 @@
 import { act } from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/test/mocks/server';
@@ -370,5 +370,39 @@ describe('AiSessionPanel', () => {
       expect(onConfirm).toHaveBeenCalledWith(expect.stringContaining('订单'));
     });
     expect(screen.queryByRole('button', { name: /确认落库/ })).not.toBeInTheDocument();
+  });
+
+  it('does not send when Enter is pressed during IME composition', async () => {
+    let createAttempts = 0;
+    server.use(
+      http.post('/api/ai/sessions', () => {
+        createAttempts += 1;
+        return HttpResponse.json({ success: true, code: '0', message: '', traceId: null, data: 100 });
+      }),
+    );
+    renderPanel();
+    const textarea = screen.getByPlaceholderText(/输入/);
+    fireEvent.change(textarea, { target: { value: '候选词' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', isComposing: true });
+    await new Promise((r) => setTimeout(r, 100));
+    expect(createAttempts).toBe(0);
+    expect(textarea).toHaveValue('候选词');
+  });
+
+  it('does not send on Shift+Enter', async () => {
+    let createAttempts = 0;
+    server.use(
+      http.post('/api/ai/sessions', () => {
+        createAttempts += 1;
+        return HttpResponse.json({ success: true, code: '0', message: '', traceId: null, data: 100 });
+      }),
+    );
+    renderPanel();
+    const textarea = screen.getByPlaceholderText(/输入/);
+    fireEvent.change(textarea, { target: { value: '第一行' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', shiftKey: true });
+    await new Promise((r) => setTimeout(r, 100));
+    expect(createAttempts).toBe(0);
+    expect(textarea).toHaveValue('第一行');
   });
 });

--- a/ai-sdlc/auto-wonder/frontend/src/shared/ui/AiSessionPanel.tsx
+++ b/ai-sdlc/auto-wonder/frontend/src/shared/ui/AiSessionPanel.tsx
@@ -52,6 +52,7 @@ export function AiSessionPanel({ scene, bizRefType, bizRefId, autoStartInput, on
   const bottomRef = useRef<HTMLDivElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const autoStartedRef = useRef(false);
+  const composingRef = useRef(false);
   const sessionId = session?.id;
   const sessionStatus = session?.status;
 
@@ -280,7 +281,16 @@ export function AiSessionPanel({ scene, bizRefType, bizRefId, autoStartInput, on
             placeholder="输入消息..."
             autoSize={{ minRows: 1, maxRows: 4 }}
             disabled={!canSend}
-            onPressEnter={(e) => { if (!e.shiftKey) { e.preventDefault(); handleSend(); } }}
+            onKeyDown={(e) => {
+              if (e.nativeEvent.isComposing || composingRef.current) return;
+              if (e.shiftKey) return;
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleSend();
+              }
+            }}
+            onCompositionStart={() => { composingRef.current = true; }}
+            onCompositionEnd={() => { composingRef.current = false; }}
           />
           <Button type="primary" icon={<SendOutlined />} onClick={handleSend} loading={loading} disabled={!canSend}>
             发送

--- a/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/SKILL.md
+++ b/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/SKILL.md
@@ -81,8 +81,8 @@ Run phases in order and record terminal results in the manifest. Read
 | 1. Preflight | `scripts/preflight.sh` (`--profile` locks a verified CLI profile) | validated tools, identity, inputs/inventory |
 | 2. Plan | `scripts/terraform-stage.sh plan` | reviewed plan fingerprint |
 | 3. Apply | `scripts/terraform-stage.sh apply`, then `inventory` | Infrastructure ready |
-| 4. Build | `scripts/build-release.sh` | sealed local JAR and schema |
-| 5. Host/DB/runtime | `scripts/initialize-and-verify.sh runtime-config`; `scripts/deploy-via-cloud-assistant.sh`; then `scripts/initialize-and-verify.sh database` | Java 21, clients, release, env (including public base URL), systemd, schema installed |
+| 4. Build | `scripts/build-release.sh` | sealed local JAR, schema, and template seed |
+| 5. Host/DB/runtime | `scripts/initialize-and-verify.sh runtime-config`; `scripts/deploy-via-cloud-assistant.sh`; then `scripts/initialize-and-verify.sh database` | Java 21, clients, release, env (including public base URL), systemd, schema and four system templates installed |
 | 6. Rolling activation | `scripts/initialize-and-verify.sh rolling-start` | Application ready |
 | 7. Business init | `scripts/initialize-and-verify.sh business-init` | Business initialized |
 | 8. Acceptance | `scripts/initialize-and-verify.sh acceptance` | Release accepted; TLS independently checked |
@@ -95,6 +95,11 @@ Cloud Assistant invocation IDs are checkpointed immediately. After an env-only
 correction, use `deploy-via-cloud-assistant.sh --config-only`; do not upload the
 JAR, schema, systemd unit, or Java archive again. Acceptance reruns preserve
 already-passed deep checks instead of resetting them to pending.
+
+The immutable release includes `autowonder-community-templates.sql`. Database
+initialization imports it after the schema and records
+`.database.templatesImported`. On an older manifest without this checkpoint,
+resume the database phase to run only the idempotent template seed and postcheck.
 
 For teardown, read `references/acceptance-and-rollback.md`, run
 `scripts/terraform-stage.sh destroy-plan`, review backups/impact/hash, and obtain

--- a/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/references/operations-runbook.md
+++ b/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/references/operations-runbook.md
@@ -62,9 +62,10 @@ protection, listener sources, private endpoints, and application RAM scope.
 ## Phase 4: Immutable Build And Transfer
 
 Run `scripts/build-release.sh` against the exact repository commit. It runs the
-complete build verification, records JAR/schema hashes, and refuses a dirty or
-mismatched source. Phase 4 ends with the sealed local release; host transfer
-starts only after runtime configuration exists in Phase 5.
+complete build verification, records JAR/schema/template-seed hashes, and refuses
+a dirty or mismatched source. The seed artifact is
+`autowonder-community-templates.sql`. Phase 4 ends with the sealed local release;
+host transfer starts only after runtime configuration exists in Phase 5.
 
 Do not use Cloud Assistant `SendFile` for a JAR, runtime, or secret file. Do not
 build from source on ECS. If Java 21 is absent, transfer a pinned, verified
@@ -87,7 +88,10 @@ verify hashes, and install the versioned layout, Java runtime, data/log
 directories, and systemd unit. The control host uploads and deletes through the
 public OSS endpoint; presigned ECS downloads use the intranet endpoint. Finally run
 `initialize-and-verify.sh database`: confirm empty state, import schema in its
-own invocation, then run the separate read-only postcondition. Never rerun DDL
+own invocation, import the idempotent four-template seed, then run the separate
+read-only postcondition. `.database.imported` checkpoints schema and
+`.database.templatesImported` checkpoints templates. A legacy manifest missing
+only the latter runs the seed without repeating schema DDL. Never rerun DDL
 because post-validation failed.
 
 The current Alibaba Cloud CLI accepts raw `CommandContent` and performs API

--- a/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/scripts/build-release.sh
+++ b/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/scripts/build-release.sh
@@ -30,13 +30,18 @@ expected=$(json_string "$manifest" '.repositoryCommit')
 git -C "$source_dir" merge-base --is-ancestor "$actual" "$actual" || die "commit is unavailable"
 (cd "$source_dir" && mvn -DskipGitCommitId=true clean verify)
 jar="$source_dir/target/auto-wonder.jar"; schema="$source_dir/docs/autowonder-schema.sql"
-require_file "$jar"; require_file "$schema"
+templates="$source_dir/docs/autowonder-community-templates.sql"
+require_file "$jar"; require_file "$schema"; require_file "$templates"
 mkdir -p "$output_dir"; chmod 700 "$output_dir"
 install -m 0444 "$jar" "$output_dir/auto-wonder.jar"
 install -m 0444 "$schema" "$output_dir/autowonder-schema.sql"
+install -m 0444 "$templates" "$output_dir/autowonder-community-templates.sql"
 jar_hash=$(sha256_file "$output_dir/auto-wonder.jar"); schema_hash=$(sha256_file "$output_dir/autowonder-schema.sql")
+templates_hash=$(sha256_file "$output_dir/autowonder-community-templates.sql")
 jar_size=$(wc -c <"$output_dir/auto-wonder.jar" | tr -d ' '); schema_size=$(wc -c <"$output_dir/autowonder-schema.sql" | tr -d ' ')
-atomic_jq "$manifest" --arg commit "$actual" --arg jarHash "$jar_hash" --arg schemaHash "$schema_hash" \
-  --argjson jarSize "$jar_size" --argjson schemaSize "$schema_size" --arg dir "$output_dir" \
-  '.repositoryCommit=$commit | .artifacts={releaseDirectory:$dir,jar:{name:"auto-wonder.jar",sha256:$jarHash,size:$jarSize},schema:{name:"autowonder-schema.sql",sha256:$schemaHash,size:$schemaSize}} | .phase="build" | .status="sealed"'
-printf 'JAR %s bytes SHA256 %s\nSchema %s bytes SHA256 %s\n' "$jar_size" "$jar_hash" "$schema_size" "$schema_hash"
+templates_size=$(wc -c <"$output_dir/autowonder-community-templates.sql" | tr -d ' ')
+atomic_jq "$manifest" --arg commit "$actual" --arg jarHash "$jar_hash" --arg schemaHash "$schema_hash" --arg templatesHash "$templates_hash" \
+  --argjson jarSize "$jar_size" --argjson schemaSize "$schema_size" --argjson templatesSize "$templates_size" --arg dir "$output_dir" \
+  '.repositoryCommit=$commit | .artifacts={releaseDirectory:$dir,jar:{name:"auto-wonder.jar",sha256:$jarHash,size:$jarSize},schema:{name:"autowonder-schema.sql",sha256:$schemaHash,size:$schemaSize},templates:{name:"autowonder-community-templates.sql",sha256:$templatesHash,size:$templatesSize}} | .phase="build" | .status="sealed"'
+printf 'JAR %s bytes SHA256 %s\nSchema %s bytes SHA256 %s\nTemplates %s bytes SHA256 %s\n' \
+  "$jar_size" "$jar_hash" "$schema_size" "$schema_hash" "$templates_size" "$templates_hash"

--- a/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/scripts/deploy-via-cloud-assistant.sh
+++ b/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/scripts/deploy-via-cloud-assistant.sh
@@ -28,7 +28,8 @@ while (($#)); do
 done
 require_file "$manifest"; require_file "$env_file"
 if [[ "$config_only" == false ]]; then
-  require_file "$release_dir/auto-wonder.jar"; require_file "$release_dir/autowonder-schema.sql"; require_file "$unit_file"
+  require_file "$release_dir/auto-wonder.jar"; require_file "$release_dir/autowonder-schema.sql"
+  require_file "$release_dir/autowonder-community-templates.sql"; require_file "$unit_file"
 fi
 require_mode_600 "$env_file"; require_command jq
 json_validate "$manifest"; reject_secret_keys "$manifest"
@@ -39,11 +40,12 @@ bucket=$(jq -er '.resources.package_bucket // .resources.packageBucket // empty'
 instances=()
 while IFS= read -r instance; do instances+=("$instance"); done < <(jq -er '(.resources.ecs_instance_ids // .resources.ecsInstanceIds)[]' "$manifest")
 ((${#instances[@]} > 0)) || die "ECS inventory is empty"
-jar_hash= unit_hash= schema_hash= java_hash=
+jar_hash= unit_hash= schema_hash= templates_hash= java_hash=
 env_hash=$(sha256_file "$env_file")
 if [[ "$config_only" == false ]]; then
   jar_hash=$(sha256_file "$release_dir/auto-wonder.jar"); unit_hash=$(sha256_file "$unit_file")
   schema_hash=$(sha256_file "$release_dir/autowonder-schema.sql")
+  templates_hash=$(sha256_file "$release_dir/autowonder-community-templates.sql")
   [[ -z "$java_archive" ]] || { require_file "$java_archive"; java_hash=$(sha256_file "$java_archive"); }
 fi
 prefix="deployments/${deployment_id}/${short_commit}-$(date -u +%Y%m%dT%H%M%SZ)-$$"
@@ -66,8 +68,8 @@ fi
 
 objects=("autowonder.env"); files=("$env_file")
 if [[ "$config_only" == false ]]; then
-  objects=("auto-wonder.jar" "autowonder-schema.sql" "autowonder.service" "autowonder.env")
-  files=("$release_dir/auto-wonder.jar" "$release_dir/autowonder-schema.sql" "$unit_file" "$env_file")
+  objects=("auto-wonder.jar" "autowonder-schema.sql" "autowonder-community-templates.sql" "autowonder.service" "autowonder.env")
+  files=("$release_dir/auto-wonder.jar" "$release_dir/autowonder-schema.sql" "$release_dir/autowonder-community-templates.sql" "$unit_file" "$env_file")
   if [[ -n "$java_archive" ]]; then objects+=("temurin21-linux-amd64.tar.gz"); files+=("$java_archive"); fi
 fi
 for idx in "${!objects[@]}"; do
@@ -114,10 +116,11 @@ run_cloud_command() {
 }
 
 invocations=()
-jar_url= schema_url= unit_url= java_url=
+jar_url= schema_url= templates_url= unit_url= java_url=
 env_url=$(presign_object autowonder.env)
 if [[ "$config_only" == false ]]; then
-  jar_url=$(presign_object auto-wonder.jar); schema_url=$(presign_object autowonder-schema.sql); unit_url=$(presign_object autowonder.service)
+  jar_url=$(presign_object auto-wonder.jar); schema_url=$(presign_object autowonder-schema.sql)
+  templates_url=$(presign_object autowonder-community-templates.sql); unit_url=$(presign_object autowonder.service)
   [[ -z "$java_archive" ]] || java_url=$(presign_object temurin21-linux-amd64.tar.gz)
 fi
 for instance in "${instances[@]}"; do
@@ -156,6 +159,10 @@ curl --fail --silent --show-error '$schema_url' -o /opt/autowonder/releases/$sho
 echo '$schema_hash  /opt/autowonder/releases/$short_commit/autowonder-schema.sql.tmp' | sha256sum -c -
 mv /opt/autowonder/releases/$short_commit/autowonder-schema.sql.tmp /opt/autowonder/releases/$short_commit/autowonder-schema.sql
 chmod 0444 /opt/autowonder/releases/$short_commit/autowonder-schema.sql
+curl --fail --silent --show-error '$templates_url' -o /opt/autowonder/releases/$short_commit/autowonder-community-templates.sql.tmp
+echo '$templates_hash  /opt/autowonder/releases/$short_commit/autowonder-community-templates.sql.tmp' | sha256sum -c -
+mv /opt/autowonder/releases/$short_commit/autowonder-community-templates.sql.tmp /opt/autowonder/releases/$short_commit/autowonder-community-templates.sql
+chmod 0444 /opt/autowonder/releases/$short_commit/autowonder-community-templates.sql
 curl --fail --silent --show-error '$env_url' -o /etc/autowonder/autowonder.env.tmp
 echo '$env_hash  /etc/autowonder/autowonder.env.tmp' | sha256sum -c -
 chown root:autowonder /etc/autowonder/autowonder.env.tmp && chmod 0640 /etc/autowonder/autowonder.env.tmp
@@ -174,7 +181,7 @@ EOF
 done
 
 for object in "${objects[@]}"; do ossutil rm -f "oss://$bucket/$prefix/$object" --endpoint "$control_endpoint" >/dev/null; done
-unset jar_url schema_url unit_url env_url java_url remote
+unset jar_url schema_url templates_url unit_url env_url java_url remote
 mode=full; [[ "$config_only" == false ]] || mode=config-only
 atomic_jq "$manifest" --argjson invocations "$(printf '%s\n' "${invocations[@]}" | jq -R . | jq -s .)" \
   --arg prefix "$prefix" --arg mode "$mode" '.phase="deploy" | .status="installed" | .deployment.lastRun={mode:$mode,invocationIds:$invocations,stagingPrefix:$prefix,stagingCleaned:true,credentialTransport:"time-limited private intranet presign",transportExceptionRecorded:true}'

--- a/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/scripts/initialize-and-verify.sh
+++ b/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/scripts/initialize-and-verify.sh
@@ -103,6 +103,7 @@ case "$subcommand" in
     ;;
   database)
     imported=$(jq -r '.database.imported // false' "$manifest")
+    templates_imported=$(jq -r '.database.templatesImported // false' "$manifest")
     pre=$(run_cloud "${instances[0]}" "$remote_db_prelude
 count=\$(mysql -h \"\$host\" -P \"\$port\" -u \"\$SPRING_DATASOURCE_USERNAME\" -Nse 'SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=DATABASE()' \"\$database\")
 printf 'TABLE_COUNT=%s\\n' \"\$count\"")
@@ -113,12 +114,20 @@ printf 'TABLE_COUNT=%s\\n' \"\$count\"")
       import_result=$(run_cloud "${instances[0]}" "$remote_db_prelude
 mysql -h \"\$host\" -P \"\$port\" -u \"\$SPRING_DATASOURCE_USERNAME\" \"\$database\" < /opt/autowonder/releases/$short_commit/autowonder-schema.sql
 printf 'SCHEMA_IMPORTED\\n'")
-      atomic_jq "$manifest" --arg invocation "$(jq -r '.invocationId' <<<"$import_result")" '.database={imported:true,importInvocationId:$invocation,postcheck:false}'
+      atomic_jq "$manifest" --arg invocation "$(jq -r '.invocationId' <<<"$import_result")" '.database.imported=true | .database.importInvocationId=$invocation | .database.postcheck=false'
+    fi
+    if [[ "$templates_imported" != true ]]; then
+      template_result=$(run_cloud "${instances[0]}" "$remote_db_prelude
+mysql -h \"\$host\" -P \"\$port\" -u \"\$SPRING_DATASOURCE_USERNAME\" \"\$database\" < /opt/autowonder/releases/$short_commit/autowonder-community-templates.sql
+printf 'TEMPLATES_IMPORTED\n'")
+      atomic_jq "$manifest" --arg invocation "$(jq -r '.invocationId' <<<"$template_result")" '.database.templatesImported=true | .database.templatesImportInvocationId=$invocation | .database.postcheck=false'
     fi
     post=$(run_cloud "${instances[0]}" "$remote_db_prelude
 count=\$(mysql -h \"\$host\" -P \"\$port\" -u \"\$SPRING_DATASOURCE_USERNAME\" -Nse 'SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=DATABASE()' \"\$database\")
 for table in user org workitem agent executor; do mysql -h \"\$host\" -P \"\$port\" -u \"\$SPRING_DATASOURCE_USERNAME\" -Nse \"SELECT 1 FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name='\$table'\" \"\$database\" | grep -qx 1; done
-printf 'TABLE_COUNT=%s\\nPOSTCHECK=passed\\n' \"\$count\"")
+template_count=\$(mysql -h \"\$host\" -P \"\$port\" -u \"\$SPRING_DATASOURCE_USERNAME\" -Nse \"SELECT COUNT(*) FROM squad_template WHERE tenant_id IS NULL AND status='ACTIVE' AND is_deleted=0 AND JSON_VALID(content_json)=1 AND ((name='独立开发者' AND JSON_LENGTH(content_json, '\$.agents')=1) OR (name='开发+评审双人组' AND JSON_LENGTH(content_json, '\$.agents')=2) OR (name='标准研发交付小队' AND JSON_LENGTH(content_json, '\$.agents')=3) OR (name='全链路研发协作小队' AND JSON_LENGTH(content_json, '\$.agents')=7))\" \"\$database\")
+test \"\$template_count\" = 4
+printf 'TABLE_COUNT=%s\\nTEMPLATE_COUNT=%s\\nPOSTCHECK=passed\\n' \"\$count\" \"\$template_count\"")
     atomic_jq "$manifest" --arg invocation "$(jq -r '.invocationId' <<<"$post")" '.database.postcheck=true | .database.postcheckInvocationId=$invocation | .phase="database" | .status="initialized"'
     ;;
   rolling-start)

--- a/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/tests/test_script_contracts.py
+++ b/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/tests/test_script_contracts.py
@@ -341,6 +341,24 @@ JSON
         self.assertIn('authority=${connection%%/*}', text)
         self.assertIn('database=${connection#*/}', text)
 
+    def test_release_and_database_include_squad_template_seed(self):
+        build = (ROOT / "scripts/build-release.sh").read_text()
+        deploy = (ROOT / "scripts/deploy-via-cloud-assistant.sh").read_text()
+        initialize = (ROOT / "scripts/initialize-and-verify.sh").read_text()
+
+        seed_name = "autowonder-community-templates.sql"
+        self.assertIn(seed_name, build)
+        self.assertIn('templates:{name:"autowonder-community-templates.sql"', build)
+        self.assertIn(seed_name, deploy)
+        self.assertIn("templates_hash", deploy)
+        self.assertIn(".database.templatesImported // false", initialize)
+        self.assertIn(seed_name, initialize)
+        self.assertIn("TEMPLATE_COUNT=", initialize)
+        self.assertLess(
+            initialize.index("autowonder-schema.sql"),
+            initialize.index(seed_name),
+        )
+
     def test_sanitizer_removes_sensitive_fields_and_identifiers(self):
         with tempfile.TemporaryDirectory() as td:
             source = Path(td) / "evidence.json"

--- a/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/tests/test_skill_bundle.py
+++ b/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/tests/test_skill_bundle.py
@@ -72,6 +72,8 @@ REQUIRED_SKILL_TERMS = [
     "Business initialized",
     "Release accepted",
     "TLS accepted",
+    "autowonder-community-templates.sql",
+    "templatesImported",
 ]
 
 

--- a/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/tests/test_squad_template_seed.py
+++ b/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/tests/test_squad_template_seed.py
@@ -1,0 +1,102 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SEED = ROOT / "docs" / "autowonder-community-templates.sql"
+
+EXPECTED_COUNTS = {
+    "solo": ("独立开发者", 1),
+    "pair": ("开发+评审双人组", 2),
+    "delivery": ("标准研发交付小队", 3),
+    "full_cycle": ("全链路研发协作小队", 7),
+}
+FULL_CYCLE_ROLES = {
+    "REQ_CLARIFIER",
+    "PROJECT_MANAGER",
+    "FS_DEV",
+    "CR",
+    "QA",
+    "CONFLICT_RESOLVER",
+    "DBA",
+}
+PLACEHOLDERS = {
+    "SOURCE_REPOSITORY",
+    "CODE_PLATFORM",
+    "DEPLOYMENT_PLATFORM",
+    "DATABASE_HOST",
+    "DATABASE_NAME",
+    "DATABASE_USER_ENV",
+}
+
+
+class SquadTemplateSeedTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.sql = SEED.read_text(encoding="utf-8")
+        pattern = re.compile(
+            r"SET @template_([a-z_]+) = '((?:[^']|'')*)';", re.DOTALL
+        )
+        cls.payloads = {
+            key: json.loads(raw.replace("''", "'"))
+            for key, raw in pattern.findall(cls.sql)
+        }
+
+    def test_contains_exactly_four_valid_payloads(self):
+        self.assertEqual(set(EXPECTED_COUNTS), set(self.payloads))
+        for key, (name, count) in EXPECTED_COUNTS.items():
+            payload = self.payloads[key]
+            self.assertEqual(name, payload["template"]["name"])
+            self.assertEqual(count, len(payload["agents"]))
+            self.assertEqual(count, payload["template"]["squadSize"])
+
+    def test_every_agent_has_unique_role_and_nonempty_sdlc(self):
+        for payload in self.payloads.values():
+            roles = [agent["roleCode"] for agent in payload["agents"]]
+            self.assertEqual(len(roles), len(set(roles)))
+            for agent in payload["agents"]:
+                self.assertTrue(agent["name"].strip())
+                self.assertTrue(agent["businessBackground"].strip())
+                self.assertTrue(agent["responsibilities"].strip())
+                steps = agent["sdlc"]["steps"]
+                self.assertTrue(steps)
+                self.assertEqual(
+                    list(range(1, len(steps) + 1)),
+                    [step["order"] for step in steps],
+                )
+                for step in steps:
+                    self.assertTrue(step["name"].strip())
+                    self.assertTrue(step["instruction"].strip())
+
+    def test_full_cycle_has_the_seven_approved_roles(self):
+        roles = {agent["roleCode"] for agent in self.payloads["full_cycle"]["agents"]}
+        self.assertEqual(FULL_CYCLE_ROLES, roles)
+
+    def test_uses_only_approved_external_placeholders(self):
+        serialized = json.dumps(self.payloads, ensure_ascii=False)
+        actual = set(re.findall(r"\{\{([A-Z_]+)}}", serialized))
+        self.assertEqual(PLACEHOLDERS, actual)
+
+    def test_seed_is_idempotent_and_environment_neutral(self):
+        self.assertEqual(4, self.sql.count("UPDATE squad_template"))
+        self.assertEqual(4, self.sql.count("INSERT INTO squad_template"))
+        self.assertEqual(4, self.sql.count("WHERE NOT EXISTS"))
+        self.assertNotRegex(self.sql, r"INSERT INTO squad_template\s*\(\s*id\b")
+
+        payload_text = json.dumps(self.payloads, ensure_ascii=False).lower()
+        for forbidden in (
+            "autowonder",
+            "aone-mix",
+            "code.alibaba",
+            "alibaba-inc.com",
+            "aliyun-inc.com",
+            "rm-0jlg",
+            "autowonderdev",
+        ):
+            self.assertNotIn(forbidden, payload_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
 ## 背景

  同步最新 AutoWonder Community 版本，补充社区初始化所需的标准研发小队模板，并合并最新 AI 需求澄清交互优化。

  ## 主要变更

  - 新增 4 个标准小队模板：
      - 独立开发者
      - 开发+评审双人组
      - 标准研发交付小队
      - 全链路研发协作小队

  - 新增幂等模板初始化 SQL。
  - 部署 Skill 支持模板 SQL 的打包、传输、初始化和状态检查。
  - 使用 .database.templatesImported 独立记录模板初始化状态，兼容已有部署 manifest。
  - AI 澄清回复落库后立即停止加载状态。
  - AI 对话输入框支持：
      - Enter 发送
      - Shift+Enter 换行
      - 输入法组词期间避免误发送

  - 更新 Community master 同步基线和操作文档。

  ## 验证

  - Maven 构建成功，后端 1713 项测试通过。
  - 前端 82 个测试文件、502 项测试通过。
  - Deployment Skill 44 项测试通过。
  - ESLint：0 errors，保留 2 个既有 Hook warnings。
  - 社区内部依赖、内部域名和文档边界扫描通过。
  - GitHub ai-sdlc/auto-wonder 目录与 community@449d16c6 快照逐文件一致。