### PR TITLE
fix(autowonder): update recommendedRuntimeVersion to 0.2.138

### DIFF
--- a/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/assets/templates/deployment-manifest.json
+++ b/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/assets/templates/deployment-manifest.json
@@ -54,7 +54,7 @@
   "repositoryUrl": "",
   "repositoryRef": "community",
   "repositoryCommit": "",
-  "recommendedRuntimeVersion": "0.2.130",
+  "recommendedRuntimeVersion": "0.2.138",
   "executionMode": "unattended",
   "tags": {
     "Project": "AutoWonder",

--- a/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/tests/test_manifest.py
+++ b/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/tests/test_manifest.py
@@ -107,7 +107,7 @@ class ManifestContractTest(unittest.TestCase):
         self.assertEqual("auto-wonder-prod", self.manifest["tags"]["Environment"])
 
     def test_recommended_runtime_matches_current_server_contract(self):
-        self.assertEqual("0.2.130", self.manifest["recommendedRuntimeVersion"])
+        self.assertEqual("0.2.138", self.manifest["recommendedRuntimeVersion"])
 
 
 if __name__ == "__main__":

--- a/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/tests/test_script_contracts.py
+++ b/ai-sdlc/auto-wonder/skills/deploying-autowonder-on-alibaba-cloud/tests/test_script_contracts.py
@@ -558,7 +558,7 @@ JSON
                 if line.startswith("AUTOWONDER_RUNTIME_RECOMMENDED_VERSION=")
             ]
             self.assertEqual(
-                ["AUTOWONDER_RUNTIME_RECOMMENDED_VERSION=0.2.130"],
+                ["AUTOWONDER_RUNTIME_RECOMMENDED_VERSION=0.2.138"],
                 version_lines,
             )
 
@@ -1187,7 +1187,7 @@ esac
             "ingressScenario": "no-domain-no-certificate", "domain": "", "publicSourceCidrs": ["198.51.100.0/24"],
             "applicationBaseUrl": "http://public-nlb.example.com",
             "releaseVersion": "0.4.0",
-            "recommendedRuntimeVersion": "0.2.130",
+            "recommendedRuntimeVersion": "0.2.138",
             "slsEnabled": True, "aoneEnabled": False, "publicEgress": False,
             "adminUsername": "admin", "organizationName": "Example", "repositoryUrl": "local",
             "repositoryRef": "community", "repositoryCommit": "HEAD",

--- a/ai-sdlc/auto-wonder/skills/upgrading-autowonder-on-alibaba-cloud/tests/test_upgrade_info.py
+++ b/ai-sdlc/auto-wonder/skills/upgrading-autowonder-on-alibaba-cloud/tests/test_upgrade_info.py
@@ -38,7 +38,7 @@ class UpgradeInfoTest(unittest.TestCase):
             "cloudProfile": "production",
             "repositoryUrl": "https://example.invalid/autowonder.git",
             "repositoryCommit": "a" * 40,
-            "recommendedRuntimeVersion": "0.2.130",
+            "recommendedRuntimeVersion": "0.2.138",
             "tags": tags,
         }
         if secret_metadata:
@@ -180,7 +180,7 @@ esac
         self.assertEqual("local", discovery["terraform"]["backendMode"])
         self.assertEqual(info / "manifest.json", manifest)
         working = json.loads(manifest.read_text(encoding="utf-8"))
-        self.assertEqual("0.2.130", working["recommendedRuntimeVersion"])
+        self.assertEqual("0.2.138", working["recommendedRuntimeVersion"])
         self.assertEqual(0o700, (self.project / "upgrade-info").stat().st_mode & 0o777)
         for path in (self.project / "upgrade-info").rglob("*.json"):
             self.assertEqual(0o600, path.stat().st_mode & 0o777, path)
@@ -329,7 +329,7 @@ esac
 
         self.assertEqual(0, result.returncode, result.stderr)
         refreshed = json.loads(manifest.read_text(encoding="utf-8"))
-        self.assertEqual("0.2.130", refreshed["recommendedRuntimeVersion"])
+        self.assertEqual("0.2.138", refreshed["recommendedRuntimeVersion"])
 
     def test_oss_backend_with_secrets_uses_private_copy_without_leaking(self):
         deployment = self.create_deployment(secret_metadata=True)


### PR DESCRIPTION
The deployment manifest and tests were still referencing 0.2.130. External deployments would install an outdated executor runtime version.